### PR TITLE
Quick bugfixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ help: Makefile
 
 ## devenv:   install software development pre-requisites
 devenv:
-	pip install --upgrade pip setuptools pytest>=4.0.0 pytest-cov pytest-xdist pycodestyle cython sphinx sphinx-argparse
+	pip install --upgrade pip setuptools 'pytest>=4.0,<5.0' pytest-cov pytest-xdist pycodestyle cython sphinx sphinx-argparse
 
 ## style:    check Python code style against PEP8
 style:

--- a/kevlar/readgraph.py
+++ b/kevlar/readgraph.py
@@ -38,7 +38,7 @@ class ReadGraph(networkx.Graph):
         return sg
 
     def get_record(self, recordname):
-        return self.node[recordname]['record']
+        return self.nodes[recordname]['record']
 
     def load(self, readstream, minabund=None, maxabund=None, dedup=False):
         """

--- a/kevlar/reference.py
+++ b/kevlar/reference.py
@@ -10,6 +10,7 @@
 import os.path
 import re
 from subprocess import Popen, PIPE, check_call
+import sys
 from tempfile import TemporaryFile
 
 import khmer
@@ -63,7 +64,7 @@ def bwa_align(cmdargs, seqstring=None, seqfilename=None):
             bwaproc = Popen(cmdargs, stdout=samfile, stderr=PIPE)
             stdout, stderr = bwaproc.communicate()
         if bwaproc.returncode != 0:
-            kevlar.plog(stderr)
+            kevlar.plog(sys.stderr)
             raise KevlarBWAError('problem running BWA')
         samfile.seek(0)
         sam = pysam.AlignmentFile(samfile, 'r')

--- a/kevlar/tests/test_dist.py
+++ b/kevlar/tests/test_dist.py
@@ -117,7 +117,7 @@ def test_tsv():
         ]
         args = kevlar.cli.parser().parse_args(arglist)
         kevlar.dist.main(args)
-        data = pandas.read_table(distfile.name, sep='\t')
+        data = pandas.read_csv(distfile.name, sep='\t')
         print(data)
         cuml_test = [
             15.0, 18.0, 24.0, 44.0, 78.0, 153.0, 222.0, 325.0, 423.0, 515.0,


### PR DESCRIPTION
This update addresses a few bugs that have accumulated over the last several months during which this repo hasn't gotten much attention. They're the kind of minor, subtle bugs that have you scratching your head and wondering how things ever worked in the first place!

Also, pytest version is pinned to 4.x until the tests can be updated for compatibility with pytest 5.x.