### PR TITLE
Fix mock data download links

### DIFF
--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -23,8 +23,7 @@ A :doc:`more detailed tutorial is available <tutorial>`, and a complete listing 
      bwa index refr.fa.gz
 
      # Download and format configuration file
-     curl -L https://s3-us-west-1.amazonaws.com/noble-trios/helium-config.json \
-         | sed "s:/home/user/Desktop:$(pwd):g" > helium-config.json
+     curl -L https://osf.io/86adm/download  sed "s:/home/user/Desktop:$(pwd):g" > helium-config.json
 
      # Invoke the workflow
      snakemake \

--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -16,10 +16,10 @@ A :doc:`more detailed tutorial is available <tutorial>`, and a complete listing 
 .. code::
 
      # Download data
-     curl -L https://osf.io/db82p/?download -o mother.fq.gz
-     curl -L https://osf.io/6vrnz/?download -o father.fq.gz
-     curl -L https://osf.io/wt5h8/?download -o proband.fq.gz
-     curl -L https://osf.io/35wgn/?download -o refr.fa.gz
+     curl -L https://osf.io/db82p/download -o mother.fq.gz
+     curl -L https://osf.io/6vrnz/download -o father.fq.gz
+     curl -L https://osf.io/wt5h8/download -o proband.fq.gz
+     curl -L https://osf.io/35wgn/download -o refr.fa.gz
      bwa index refr.fa.gz
 
      # Download and format configuration file

--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -16,10 +16,10 @@ A :doc:`more detailed tutorial is available <tutorial>`, and a complete listing 
 .. code::
 
      # Download data
-     curl -L https://s3-us-west-1.amazonaws.com/noble-trios/helium-mother-reads.fq.gz -o mother.fq.gz
-     curl -L https://s3-us-west-1.amazonaws.com/noble-trios/helium-father-reads.fq.gz -o father.fq.gz
-     curl -L https://s3-us-west-1.amazonaws.com/noble-trios/helium-proband-reads.fq.gz -o proband.fq.gz
-     curl -L https://s3-us-west-1.amazonaws.com/noble-trios/helium-refr.fa.gz -o refr.fa.gz
+     curl -L https://osf.io/db82p/?download -o mother.fq.gz
+     curl -L https://osf.io/6vrnz/?download -o father.fq.gz
+     curl -L https://osf.io/wt5h8/?download -o proband.fq.gz
+     curl -L https://osf.io/35wgn/?download -o refr.fa.gz
      bwa index refr.fa.gz
 
      # Download and format configuration file

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -83,14 +83,14 @@ The notes above should be helpful in setting parameter values and selecting appr
 Assessing accuracy
 ------------------
 
-The output of the command above is a VCF file, and in this case should contain 10 variant calls.
+The output of the command above is a gzip-compressed VCF file, and in this case should contain 10 variant calls.
 The ``kevlar-eval.sh`` script below uses ``bedtools intersect`` to do a quick and simple evaluation of kevlar's accuracy.
 
 .. code:: bash
 
     curl -L https://osf.io/yj9nu/download -o neon-refr.vcf
     curl -L https://osf.io/nz5vt/download -o kevlar-eval.sh
-    bash kevlar-eval.sh neon-refr.vcf kevlar-variant-calls.vcf
+    bash kevlar-eval.sh neon-refr.vcf calls.scored.sorted.vcf.gz
 
 
 The kevlar simplex workflow in detail

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -13,10 +13,10 @@ The data for this tutorial comes from `a simulated 25 Mb genome <https://github.
 
 .. code::
 
-    curl -L https://s3-us-west-1.amazonaws.com/noble-trios/neon-mother-reads.fq.gz -o mother.fq.gz
-    curl -L https://s3-us-west-1.amazonaws.com/noble-trios/neon-father-reads.fq.gz -o father.fq.gz
-    curl -L https://s3-us-west-1.amazonaws.com/noble-trios/neon-proband-reads.fq.gz -o proband.fq.gz
-    curl -L https://s3-us-west-1.amazonaws.com/noble-trios/neon-refr.fa.gz -o refr.fa.gz
+    curl -L https://osf.io/b93gw/download -o mother.fq.gz
+    curl -L https://osf.io/gs6pt/download -o father.fq.gz
+    curl -L https://osf.io/np9wh/download -o proband.fq.gz
+    curl -L https://osf.io/mny56/download -o refr.fa.gz
 
 The reference genome must be indexed for BWA searches before proceeding.
 
@@ -88,8 +88,8 @@ The ``kevlar-eval.sh`` script below uses ``bedtools intersect`` to do a quick an
 
 .. code:: bash
 
-    curl -L https://s3-us-west-1.amazonaws.com/noble-trios/neon.vcf -o neon-refr.vcf
-    curl -L curl -L https://raw.githubusercontent.com/standage/noble/master/kevlar-eval.sh -o kevlar-eval.sh
+    curl -L https://osf.io/yj9nu/download -o neon-refr.vcf
+    curl -L https://osf.io/nz5vt/download -o kevlar-eval.sh
     bash kevlar-eval.sh neon-refr.vcf kevlar-variant-calls.vcf
 
 


### PR DESCRIPTION
This update fixes links to mock data for the quick start and tutorial in the kevlar docs.