### PR TITLE
Update exception handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ help: Makefile
 
 ## devenv:   install software development pre-requisites
 devenv:
-	pip install --upgrade pip setuptools 'pytest>=4.0,<5.0' pytest-cov pytest-xdist pycodestyle cython sphinx sphinx-argparse
+	pip install --upgrade pip setuptools 'pytest>=5.3' pytest-cov pytest-xdist pycodestyle cython sphinx sphinx-argparse
 
 ## style:    check Python code style against PEP8
 style:

--- a/kevlar/call.py
+++ b/kevlar/call.py
@@ -9,7 +9,6 @@
 
 from collections import defaultdict
 import kevlar
-from kevlar.reference import bwa_align
 from kevlar.varmap import VariantMapping
 from kevlar.vcf import VariantFilter as vf
 import khmer

--- a/kevlar/tests/test_cli.py
+++ b/kevlar/tests/test_cli.py
@@ -18,9 +18,8 @@ def test_kevlar_open():
     filecontents = filehandle.read()
     assert len(filecontents.strip().split('\n')) == 9
 
-    with pytest.raises(ValueError) as ve:
+    with pytest.raises(ValueError, match=r'invalid mode "p"'):
         filehandle = kevlar.open(thefile, 'p')
-    assert 'invalid mode "p"' in str(ve)
 
 
 def test_main(capsys):

--- a/kevlar/tests/test_count.py
+++ b/kevlar/tests/test_count.py
@@ -86,9 +86,9 @@ def test_count_problematic():
         'bogusoutput', data_file('trio1/ctrl1.fq')
     ]
     args = kevlar.cli.parser().parse_args(arglist)
-    with pytest.raises(ValueError) as ve:
+    errormsg = r'Must specify --num-bands and --band together'
+    with pytest.raises(ValueError, match=errormsg):
         kevlar.count.main(args)
-    assert 'Must specify --num-bands and --band together' in str(ve)
 
     arglist = [
         'count', '--ksize', '21', '--memory', '97',

--- a/kevlar/tests/test_gentrio.py
+++ b/kevlar/tests/test_gentrio.py
@@ -42,9 +42,8 @@ def test_weights_str_to_dict():
         {'snv': 0.8 / 1.2, 'ins': 0.2 / 1.2, 'del': 0.2 / 1.2}
     )
 
-    with pytest.raises(ValueError) as ve:
+    with pytest.raises(ValueError, match=r'too many values to unpack'):
         ws2d('snv=0.8;ins=0.2;del=0.2')
-    assert 'too many values to unpack' in str(ve)
 
 
 def test_rng():
@@ -179,10 +178,9 @@ def test_gen_muts():
 def test_gen_with_inversions(seed):
     seqs = {'1': 'ACGT'}
     w = {'inv': 1.0}
-    with pytest.raises(ValueError) as ve:
+    with pytest.raises(ValueError, match=r'unknown mutation type inv'):
         # Invoke the mutator!!!
         list(kevlar.gentrio.generate_mutations(seqs, weights=w, rng=seed))
-    assert 'unknown mutation type inv' in str(ve)
 
 
 def test_sim_var_geno_smoketest():

--- a/kevlar/tests/test_localize.py
+++ b/kevlar/tests/test_localize.py
@@ -141,9 +141,8 @@ def test_get_cutouts_missing_seq():
     intervals.add_seed_match('TheCakeIsALie', 77)
     refrstream = open(data_file('simple-genome-ctrl1.fa'), 'r')
     seqs = kevlar.seqio.parse_seq_dict(refrstream)
-    with pytest.raises(KevlarRefrSeqNotFoundError) as rnf:
+    with pytest.raises(KevlarRefrSeqNotFoundError, match=r'TheCakeIsALie'):
         list(intervals.get_cutouts(refrseqs=seqs))
-    assert 'TheCakeIsALie' in str(rnf)
 
 
 def test_extract_regions_boundaries():

--- a/kevlar/tests/test_mutate.py
+++ b/kevlar/tests/test_mutate.py
@@ -51,9 +51,8 @@ def test_load_mutations_y():
 
 def test_load_mutations_z():
     instream = kevlar.open(data_file('muts-z.csv'), 'r')
-    with pytest.raises(ValueError) as ve:
+    with pytest.raises(ValueError, match=r'error parsing mutation'):
         mutations = kevlar.mutate.load_mutations(instream, stderr)
-    assert 'error parsing mutation' in str(ve)
 
 
 def test_mutate_snv():
@@ -89,9 +88,8 @@ def test_mutate_inv():
 
 def test_mutate_bogus():
     instream = kevlar.open(data_file('muts-w.txt'), 'r')
-    with pytest.raises(ValueError) as ve:
+    with pytest.raises(ValueError, match=r'invalid variant type "slippage"'):
         mutations = kevlar.mutate.load_mutations(instream, stderr)
-    assert 'invalid variant type "slippage"' in str(ve)
 
 
 def test_mutate_main(capsys):

--- a/kevlar/tests/test_novel.py
+++ b/kevlar/tests/test_novel.py
@@ -23,17 +23,16 @@ from khmer import Counttable
 
 
 def test_novel_banding_args():
-    with pytest.raises(ValueError) as ve:
+    errormsg = r'Must specify `numbands` and `band` together'
+    with pytest.raises(ValueError, match=errormsg):
         reads = list(kevlar.novel.novel(None, [], [], numbands=4))
-    assert 'Must specify `numbands` and `band` together' in str(ve)
 
-    with pytest.raises(ValueError) as ve:
+    with pytest.raises(ValueError, match=errormsg):
         reads = list(kevlar.novel.novel(None, [], [], band=0))
-    assert 'Must specify `numbands` and `band` together' in str(ve)
 
-    with pytest.raises(ValueError) as ve:
+    errormsg = r'`band` must be a value between 0 and 3'
+    with pytest.raises(ValueError, match=errormsg):
         reads = list(kevlar.novel.novel(None, [], [], numbands=4, band=-1))
-    assert '`band` must be a value between 0 and 3' in str(ve)
 
 
 def test_cli():
@@ -57,13 +56,13 @@ def test_cli():
     assert args.num_bands == 8
     assert args.band == 1
 
-    with pytest.raises(ValueError) as ve:
+    errormsg = r'Must specify --num-bands and --band together'
+    with pytest.raises(ValueError, match=errormsg):
         args = kevlar.cli.parser().parse_args([
             'novel', '--case', 'case1.fq', '--control', 'cntl1.fq',
             '--band', '1'
         ])
         kevlar.novel.main(args)
-    assert 'Must specify --num-bands and --band together' in str(ve)
 
 
 @pytest.mark.parametrize('kmer', [

--- a/kevlar/tests/test_reference.py
+++ b/kevlar/tests/test_reference.py
@@ -54,17 +54,15 @@ def test_load_cutouts():
 def test_autoindex():
     origlogstream = kevlar.logstream
     # Bogus directory
-    with pytest.raises(KevlarBWAError) as e:
+    with pytest.raises(KevlarBWAError, match=r'does not exist'):
         autoindex('/a/truly/bogus/dir/seqs.fa')
-    assert 'does not exist' in str(e)
 
     tmpdir = mkdtemp()
     try:
         # Real directory, non-existent file
         filename = tmpdir + '/refr.fa'
-        with pytest.raises(KevlarBWAError) as e:
+        with pytest.raises(KevlarBWAError, match=r'does not exist'):
             autoindex(filename)
-        assert 'does not exist' in str(e)
 
         # Should successfully index the sequence
         kevlar.logstream = StringIO()

--- a/kevlar/tests/test_reference.py
+++ b/kevlar/tests/test_reference.py
@@ -87,6 +87,7 @@ def test_bwa_align_coords():
            'GCCAGCCCTGGTTTCAAAATTGTTCCTCAGCATT')
     fasta = '>seq1\n{}\n'.format(seq)
     args = ['bwa', 'mem', data_file('fiveparts-refr.fa.gz'), '-']
+    kevlar.reference.autoindex(data_file('fiveparts-refr.fa.gz'))
     aligner = kevlar.reference.bwa_align(args, fasta)
     mappings = list(aligner)
     assert len(mappings) == 1

--- a/kevlar/tests/test_seqio.py
+++ b/kevlar/tests/test_seqio.py
@@ -195,7 +195,8 @@ def test_partition_reader_simple():
 def test_partition_reader_mixed():
     infile = data_file('part-reads-mixed.fa')
     readstream = kevlar.parse_augmented_fastx(kevlar.open(infile, 'r'))
-    with pytest.raises(KevlarPartitionLabelError, match=r'with and without partition labels'):
+    errormsg = r'with and without partition labels'
+    with pytest.raises(KevlarPartitionLabelError, match=errormsg):
         partitions = list(kevlar.parse_partitioned_reads(readstream))
 
 
@@ -248,4 +249,4 @@ def test_ikmer_out_of_bounds():
     fh = kevlar.open(data_file('out-of-bounds.augfastq.gz'), 'r')
     reader = kevlar.parse_augmented_fastx(fh)
     with pytest.raises(AssertionError, match=r"('TACGACAGAC', 'TACGACAGACA')"):
-        list(reader)git a
+        list(reader)

--- a/kevlar/tests/test_seqio.py
+++ b/kevlar/tests/test_seqio.py
@@ -195,9 +195,8 @@ def test_partition_reader_simple():
 def test_partition_reader_mixed():
     infile = data_file('part-reads-mixed.fa')
     readstream = kevlar.parse_augmented_fastx(kevlar.open(infile, 'r'))
-    with pytest.raises(KevlarPartitionLabelError) as ple:
+    with pytest.raises(KevlarPartitionLabelError, match=r'with and without partition labels'):
         partitions = list(kevlar.parse_partitioned_reads(readstream))
-    assert 'with and without partition labels' in str(ple)
 
 
 def test_parse_single_partition():
@@ -248,6 +247,5 @@ def test_kevlar_open(basename):
 def test_ikmer_out_of_bounds():
     fh = kevlar.open(data_file('out-of-bounds.augfastq.gz'), 'r')
     reader = kevlar.parse_augmented_fastx(fh)
-    with pytest.raises(AssertionError) as ae:
-        list(reader)
-    assert "('TACGACAGAC', 'TACGACAGACA')" in str(ae)
+    with pytest.raises(AssertionError, match=r"('TACGACAGAC', 'TACGACAGACA')"):
+        list(reader)git a

--- a/kevlar/tests/test_simlike.py
+++ b/kevlar/tests/test_simlike.py
@@ -242,7 +242,8 @@ def test_simlike_cli_bad_labels():
         '--refr', 'refr.sct', data_file('minitrio/calls.vcf')
     ]
     args = kevlar.cli.parser().parse_args(arglist)
-    with pytest.raises(kevlar.simlike.KevlarSampleLabelingError, match=r'provided 4 labels but 3 samples'):
+    error = r'provided 4 labels but 3 samples'
+    with pytest.raises(kevlar.simlike.KevlarSampleLabelingError, match=error):
         kevlar.simlike.main(args)
 
 

--- a/kevlar/tests/test_simlike.py
+++ b/kevlar/tests/test_simlike.py
@@ -242,9 +242,8 @@ def test_simlike_cli_bad_labels():
         '--refr', 'refr.sct', data_file('minitrio/calls.vcf')
     ]
     args = kevlar.cli.parser().parse_args(arglist)
-    with pytest.raises(kevlar.simlike.KevlarSampleLabelingError) as sle:
+    with pytest.raises(kevlar.simlike.KevlarSampleLabelingError, match=r'provided 4 labels but 3 samples'):
         kevlar.simlike.main(args)
-    assert 'provided 4 labels but 3 samples' in str(sle)
 
 
 def test_simlike_fastmode():

--- a/kevlar/tests/test_sketch.py
+++ b/kevlar/tests/test_sketch.py
@@ -31,9 +31,8 @@ def test_sketch_load(filename, testkmer):
 
 def test_sketch_load_badfilename():
     infile = data_file('test.notasketchtype')
-    with pytest.raises(kevlar.sketch.KevlarSketchTypeError) as kste:
+    with pytest.raises(kevlar.sketch.KevlarSketchTypeError, match=r'sketch type from filename ' + infile):
         sketch = kevlar.sketch.load(infile)
-    assert ('sketch type from filename ' + infile) in str(kste)
 
 
 @pytest.mark.parametrize('count,smallcount', [
@@ -65,9 +64,8 @@ def test_allocate_sketch_non_graphy(count, smallcount):
     sketch.consume(sequence)
     sketch.get(kmer) == 1
     kmer_hash = sketch.hash(kmer)
-    with pytest.raises(ValueError) as ve:
+    with pytest.raises(ValueError, match=r'not implemented'):
         _ = sketch.reverse_hash(kmer_hash)
-    assert 'not implemented' in str(ve)
 
 
 def test_autoload():
@@ -95,9 +93,8 @@ def test_load_sketches():
 
 def test_load_sketches_fpr_fail():
     infiles = data_glob('test.counttable')
-    with pytest.raises(kevlar.sketch.KevlarUnsuitableFPRError) as e:
+    with pytest.raises(kevlar.sketch.KevlarUnsuitableFPRError, match=r'FPR too high, bailing out!!!'):
         sketches = kevlar.sketch.load_sketchfiles(infiles, maxfpr=0.001)
-    assert 'FPR too high, bailing out!!!' in str(e)
 
 
 def test_get_extensions():

--- a/kevlar/tests/test_sketch.py
+++ b/kevlar/tests/test_sketch.py
@@ -31,7 +31,8 @@ def test_sketch_load(filename, testkmer):
 
 def test_sketch_load_badfilename():
     infile = data_file('test.notasketchtype')
-    with pytest.raises(kevlar.sketch.KevlarSketchTypeError, match=r'sketch type from filename ' + infile):
+    errormsg = r'sketch type from filename ' + infile
+    with pytest.raises(kevlar.sketch.KevlarSketchTypeError, match=errormsg):
         sketch = kevlar.sketch.load(infile)
 
 
@@ -93,7 +94,8 @@ def test_load_sketches():
 
 def test_load_sketches_fpr_fail():
     infiles = data_glob('test.counttable')
-    with pytest.raises(kevlar.sketch.KevlarUnsuitableFPRError, match=r'FPR too high, bailing out!!!'):
+    errormsg = r'FPR too high, bailing out!!!'
+    with pytest.raises(kevlar.sketch.KevlarUnsuitableFPRError, match=errormsg):
         sketches = kevlar.sketch.load_sketchfiles(infiles, maxfpr=0.001)
 
 

--- a/kevlar/tests/test_timer.py
+++ b/kevlar/tests/test_timer.py
@@ -20,9 +20,8 @@ def test_testy_mctestface(capsys):
     time.sleep(0.1)
     assert t.probe() > 0
     assert t.probe('task1') > 0.0
-    with pytest.raises(ValueError) as ve:
+    with pytest.raises(ValueError, match=r'No timer started for "task2"'):
         t.probe('task2')
-    assert 'No timer started for "task2"' in str(ve)
     elapsed = t.stop('task1')
     assert elapsed > 0.0
     t.start('task2')
@@ -30,10 +29,8 @@ def test_testy_mctestface(capsys):
     assert t.probe('task2') > 0.0
     elapsed = t.stop('task2')
     assert elapsed > 0.0
-    with pytest.raises(ValueError) as ve:
+    with pytest.raises(ValueError, match=r'No timer started for "task3"'):
         t.stop('task3')
-    assert 'No timer started for "task3"' in str(ve)
     t.start('task3')
-    with pytest.raises(ValueError) as ve:
+    with pytest.raises(ValueError, match=r'Timer already started for "task3"'):
         t.start('task3')
-    assert 'Timer already started for "task3"' in str(ve)

--- a/kevlar/tests/test_vcf.py
+++ b/kevlar/tests/test_vcf.py
@@ -188,9 +188,9 @@ def test_writer_bad_fmt(yrb_writer):
     v.format('NA19240', 'GT', '0/1')
     v.format('NA19239', 'ALTABUND', '0,0,0')
     v.format('NA19240', 'ALTABUND', '0,0,0')
-    with pytest.raises(kevlar.vcf.VariantAnnotationError) as vae:
+    errormsg = r'samples not annotated with the same FORMAT fields'
+    with pytest.raises(kevlar.vcf.VariantAnnotationError, match=errormsg):
         yrb_writer.write(v)
-    assert 'samples not annotated with the same FORMAT fields' in str(vae)
 
 
 def test_reader():
@@ -207,15 +207,14 @@ def test_reader():
 
 
 @pytest.mark.parametrize('filename,errormsg', [
-    ('five-snvs-fmt-mismatch.vcf', 'sample number mismatch'),
-    ('five-snvs-fmtstr-mismatch.vcf', 'format data mismatch'),
+    ('five-snvs-fmt-mismatch.vcf', r'sample number mismatch'),
+    ('five-snvs-fmtstr-mismatch.vcf', r'format data mismatch'),
 ])
 def test_reader_format_mismatch(filename, errormsg):
     instream = kevlar.open(data_file(filename), 'r')
     reader = kevlar.vcf.VCFReader(instream)
-    with pytest.raises(kevlar.vcf.VariantAnnotationError) as vae:
+    with pytest.raises(kevlar.vcf.VariantAnnotationError, match=errormsg):
         calls = list(reader)
-    assert errormsg in str(vae)
 
 
 def test_vcf_roundtrip(capsys):


### PR DESCRIPTION
This update fixes exception handling in the test suite. See https://github.com/pytest-dev/pytest/issues/6260. The previously offending tests didn't fail with pytest 5.3.0 (released just days ago) due to a change in the exceptions' string representation. Now the tests are implemented correctly and should pass for pytest >= 5.0.